### PR TITLE
Feature/exception control

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,6 @@
+2019-01-23  Kirit Saelensminde  <kirit@felspar.com>
+ Add `test.throw` view to help with testing and `control.exception.catch` for running alternative views when exceptions are thrown.
+
 2019-01-09  Sem  <cloudtimewater@gmail.com>
  Fix fost.proxy.transparent. Pass the correct path.
 

--- a/Cpp/fost-urlhandler/CMakeLists.txt
+++ b/Cpp/fost-urlhandler/CMakeLists.txt
@@ -27,6 +27,7 @@ add_library(fost-urlhandler
         responses.static.cpp
         routing.cpp
         schema.validate.cpp
+        test.throw.cpp
         view.cpp
     )
 target_include_directories(fost-urlhandler PUBLIC ../include)
@@ -43,6 +44,7 @@ if(TARGET check)
             responses.405-tests.cpp
             routing-tests.cpp
             schema.validate-tests.cpp
+            test.throw.tests.cpp
             view-tests.cpp
         )
     target_link_libraries(fost-urlhandler-smoke fost-urlhandler)

--- a/Cpp/fost-urlhandler/CMakeLists.txt
+++ b/Cpp/fost-urlhandler/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_library(fost-urlhandler
         config.cpp
+        control.exception.cpp
         control.status-condition.cpp
         file.cpp
         fost-urlhandler.cpp
@@ -37,6 +38,7 @@ install(TARGETS fost-urlhandler LIBRARY DESTINATION lib ARCHIVE DESTINATION lib)
 
 if(TARGET check)
     add_library(fost-urlhandler-smoke STATIC EXCLUDE_FROM_ALL
+            control.exception.tests.cpp
             control.status-condition-tests.cpp
             responses.301-tests.cpp
             responses.302-tests.cpp

--- a/Cpp/fost-urlhandler/control.exception.cpp
+++ b/Cpp/fost-urlhandler/control.exception.cpp
@@ -1,0 +1,35 @@
+/**
+    Copyright 2019 Felspar Co Ltd. <http://support.felspar.com/>
+
+    Distributed under the Boost Software License, Version 1.0.
+    See <http://www.boost.org/LICENSE_1_0.txt>
+*/
+
+
+#include "fost-urlhandler.hpp"
+#include <fost/urlhandler.hpp>
+
+
+namespace {
+
+
+    const class catch_exception final : public fostlib::urlhandler::view {
+      public:
+        catch_exception() : view("control.exception.catch") {}
+
+        std::pair<boost::shared_ptr<fostlib::mime>, int> operator()(
+                const fostlib::json &config,
+                const fostlib::string &path,
+                fostlib::http::server::request &req,
+                const fostlib::host &host) const override {
+            return view::execute(config["try"], path, req, host);
+//             throw fostlib::exceptions::not_implemented(__PRETTY_FUNCTION__);
+        }
+
+    } C_catch_exception;
+
+
+}
+
+const fostlib::urlhandler::view &fostlib::urlhandler::control_exception_catch =
+        C_catch_exception;

--- a/Cpp/fost-urlhandler/control.exception.tests.cpp
+++ b/Cpp/fost-urlhandler/control.exception.tests.cpp
@@ -17,7 +17,39 @@ FSL_TEST_FUNCTION(try_works) {
     fostlib::json config;
     fostlib::insert(config, "try", "fost.response.200");
     fostlib::http::server::request req;
-    auto const [response, status] = fostlib::urlhandler::control_exception_catch(
-            config, "", req, fostlib::host{});
+    auto const [response, status] =
+            fostlib::urlhandler::control_exception_catch(
+                    config, "", req, fostlib::host{});
     FSL_CHECK_EQ(status, 200);
+}
+
+
+FSL_TEST_FUNCTION(catches_std_exception) {
+    fostlib::json config;
+    fostlib::insert(config, "try", "view", "test.throw");
+    fostlib::insert(
+            config, "try", "configuration", "exception", "std::logic_error");
+    fostlib::insert(config, "catch", "std::exception", "fost.response.200");
+    fostlib::http::server::request req;
+    auto const [response, status] =
+            fostlib::urlhandler::control_exception_catch(
+                    config, "", req, fostlib::host{});
+    FSL_CHECK_EQ(status, 200);
+}
+
+
+FSL_TEST_FUNCTION(missing_catch_rethrows) {
+    fostlib::json config;
+    fostlib::insert(config, "try", "view", "test.throw");
+    fostlib::insert(
+            config, "try", "configuration", "exception", "std::logic_error");
+    fostlib::http::server::request req;
+    try {
+        auto const [response, status] =
+                fostlib::urlhandler::control_exception_catch(
+                        config, "", req, fostlib::host{});
+        FSL_CHECK(false);
+    } catch (const std::logic_error &) {
+        // OK, test passed
+    }
 }

--- a/Cpp/fost-urlhandler/control.exception.tests.cpp
+++ b/Cpp/fost-urlhandler/control.exception.tests.cpp
@@ -1,0 +1,23 @@
+/**
+    Copyright 2019 Felspar Co Ltd. <http://support.felspar.com/>
+
+    Distributed under the Boost Software License, Version 1.0.
+    See <http://www.boost.org/LICENSE_1_0.txt>
+*/
+
+
+#include <fost/urlhandler>
+#include <fost/test>
+
+
+FSL_TEST_SUITE(catch_exception);
+
+
+FSL_TEST_FUNCTION(try_works) {
+    fostlib::json config;
+    fostlib::insert(config, "try", "fost.response.200");
+    fostlib::http::server::request req;
+    auto const [response, status] = fostlib::urlhandler::control_exception_catch(
+            config, "", req, fostlib::host{});
+    FSL_CHECK_EQ(status, 200);
+}

--- a/Cpp/fost-urlhandler/control.status-condition.cpp
+++ b/Cpp/fost-urlhandler/control.status-condition.cpp
@@ -1,8 +1,8 @@
-/*
-    Copyright 2018 Felspar Co Ltd. http://odin.felspar.com/
+/**
+    Copyright 2018-2019 Felspar Co Ltd. <http://support.felspar.com/>
+
     Distributed under the Boost Software License, Version 1.0.
-    See accompanying file LICENSE_1_0.txt or copy at
-        http://www.boost.org/LICENSE_1_0.txt
+    See <http://www.boost.org/LICENSE_1_0.txt>
 */
 
 
@@ -13,34 +13,44 @@
 #include <f5/json/assertions.hpp>
 #include <f5/json/schema.hpp>
 
-const class control_status_condition : public fostlib::urlhandler::view {
-  public:
-    control_status_condition() : view("fost.control.status-condition") {}
 
-    std::pair<boost::shared_ptr<fostlib::mime>, int> operator()(
-            const fostlib::json &config,
-            const fostlib::string &path,
-            fostlib::http::server::request &req,
-            const fostlib::host &host) const {
-        auto if_response = execute(config["if"], path, req, host);
-        auto if_status_code = if_response.second;
-        fostlib::string then_view = "then." + std::to_string(if_status_code);
-        if (config.has_key(then_view)) {
-            return execute(config[then_view], path, req, host);
-        } else if (if_status_code < 400) {
-            if (config.has_key("then")) {
-                return execute(config["then"], path, req, host);
+namespace {
+
+
+    const class control_status_condition : public fostlib::urlhandler::view {
+      public:
+        control_status_condition() : view("fost.control.status-condition") {}
+
+        std::pair<boost::shared_ptr<fostlib::mime>, int> operator()(
+                const fostlib::json &config,
+                const fostlib::string &path,
+                fostlib::http::server::request &req,
+                const fostlib::host &host) const {
+            auto if_response = execute(config["if"], path, req, host);
+            auto if_status_code = if_response.second;
+            fostlib::string then_view =
+                    "then." + std::to_string(if_status_code);
+            if (config.has_key(then_view)) {
+                return execute(config[then_view], path, req, host);
+            } else if (if_status_code < 400) {
+                if (config.has_key("then")) {
+                    return execute(config["then"], path, req, host);
+                }
+                return if_response;
             }
-            return if_response;
+            if (config.has_key("else")) {
+                return execute(config["else"], path, req, host);
+            }
+            throw fostlib::exceptions::not_implemented(
+                    __PRETTY_FUNCTION__,
+                    "'else' condition in fost.control.status-condition not "
+                    "defined",
+                    config);
         }
-        if (config.has_key("else")) {
-            return execute(config["else"], path, req, host);
-        }
-        throw fostlib::exceptions::not_implemented(
-                __PRETTY_FUNCTION__,
-                "else condition in fost.contro.status-condition not defined");
-    }
-} c_control_status_condition;
+    } c_control_status_condition;
+
+
+}
 
 const fostlib::urlhandler::view &fostlib::urlhandler::control_status_condition =
         c_control_status_condition;

--- a/Cpp/fost-urlhandler/test.throw.cpp
+++ b/Cpp/fost-urlhandler/test.throw.cpp
@@ -1,0 +1,34 @@
+/**
+    Copyright 2019 Felspar Co Ltd. <http://support.felspar.com/>
+
+    Distributed under the Boost Software License, Version 1.0.
+    See <http://www.boost.org/LICENSE_1_0.txt>
+*/
+
+
+#include "fost-urlhandler.hpp"
+#include <fost/urlhandler.hpp>
+
+
+namespace {
+
+
+    const class throw_exception : public fostlib::urlhandler::view {
+      public:
+        throw_exception() : view("test.throw") {}
+
+        std::pair<boost::shared_ptr<fostlib::mime>, int> operator()(
+                const fostlib::json &config,
+                const fostlib::string &path,
+                fostlib::http::server::request &req,
+                const fostlib::host &host) const override {
+            throw fostlib::exceptions::not_implemented(__PRETTY_FUNCTION__);
+        }
+
+    } C_throw_exception;
+
+
+}
+
+const fostlib::urlhandler::view &fostlib::urlhandler::test_throw =
+        C_throw_exception;

--- a/Cpp/fost-urlhandler/test.throw.cpp
+++ b/Cpp/fost-urlhandler/test.throw.cpp
@@ -9,6 +9,8 @@
 #include "fost-urlhandler.hpp"
 #include <fost/urlhandler.hpp>
 
+#include <stdexcept>
+
 
 namespace {
 

--- a/Cpp/fost-urlhandler/test.throw.cpp
+++ b/Cpp/fost-urlhandler/test.throw.cpp
@@ -35,7 +35,7 @@ namespace {
                                         "Test exception message from "
                                         "test.throw");
                 if (config["exception"] == "std::logic_error") {
-                    throw std::logic_error{static_cast<std::string>(message)};
+                    throw std::logic_error{message.std_str()};
                 } else {
                     throw fostlib::exceptions::not_implemented(
                             __PRETTY_FUNCTION__);

--- a/Cpp/fost-urlhandler/test.throw.cpp
+++ b/Cpp/fost-urlhandler/test.throw.cpp
@@ -13,7 +13,7 @@
 namespace {
 
 
-    const class throw_exception : public fostlib::urlhandler::view {
+    const class throw_exception final : public fostlib::urlhandler::view {
       public:
         throw_exception() : view("test.throw") {}
 
@@ -22,7 +22,23 @@ namespace {
                 const fostlib::string &path,
                 fostlib::http::server::request &req,
                 const fostlib::host &host) const override {
-            throw fostlib::exceptions::not_implemented(__PRETTY_FUNCTION__);
+            if (config.isnull()) {
+                throw std::invalid_argument{
+                        "Null configuration given to test.throw"};
+            } else {
+                fostlib::string const message =
+                        fostlib::coerce<std::optional<f5::u8view>>(
+                                config["message"])
+                                .value_or(
+                                        "Test exception message from "
+                                        "test.throw");
+                if (config["exception"] == "std::logic_error") {
+                    throw std::logic_error{static_cast<std::string>(message)};
+                } else {
+                    throw fostlib::exceptions::not_implemented(
+                            __PRETTY_FUNCTION__);
+                }
+            }
         }
 
     } C_throw_exception;

--- a/Cpp/fost-urlhandler/test.throw.tests.cpp
+++ b/Cpp/fost-urlhandler/test.throw.tests.cpp
@@ -1,0 +1,24 @@
+/**
+    Copyright 2019 Felspar Co Ltd. <http://support.felspar.com/>
+
+    Distributed under the Boost Software License, Version 1.0.
+    See <http://www.boost.org/LICENSE_1_0.txt>
+*/
+
+
+#include <fost/urlhandler>
+#include <fost/test>
+
+
+FSL_TEST_SUITE(throw_exception);
+
+
+FSL_TEST_FUNCTION(not_implemented) {
+    fostlib::json config;
+    fostlib::http::server::request req;
+    try {
+        auto const response{fostlib::urlhandler::test_throw(
+                config, "", req, fostlib::host{})};
+        FSL_CHECK(false);
+    } catch (fostlib::exceptions::not_implemented &) {}
+}

--- a/Cpp/fost-urlhandler/test.throw.tests.cpp
+++ b/Cpp/fost-urlhandler/test.throw.tests.cpp
@@ -13,12 +13,36 @@
 FSL_TEST_SUITE(throw_exception);
 
 
-FSL_TEST_FUNCTION(not_implemented) {
+FSL_TEST_FUNCTION(empty_config) {
     fostlib::json config;
     fostlib::http::server::request req;
     try {
         auto const response{fostlib::urlhandler::test_throw(
                 config, "", req, fostlib::host{})};
         FSL_CHECK(false);
-    } catch (fostlib::exceptions::not_implemented &) {}
+    } catch (std::invalid_argument &) {}
+}
+
+
+FSL_TEST_FUNCTION(logic_error) {
+    fostlib::json config;
+    fostlib::insert(config, "exception", "std::logic_error");
+    fostlib::http::server::request req;
+    try {
+        auto const response{fostlib::urlhandler::test_throw(
+                config, "", req, fostlib::host{})};
+        FSL_CHECK(false);
+    } catch (std::logic_error &e) {
+        FSL_CHECK_EQ(
+                e.what(),
+                std::string{"Test exception message from test.throw"});
+    }
+    fostlib::insert(config, "message", "Message set");
+    try {
+        auto const response{fostlib::urlhandler::test_throw(
+                config, "", req, fostlib::host{})};
+        FSL_CHECK(false);
+    } catch (std::logic_error &e) {
+        FSL_CHECK_EQ(e.what(), std::string{"Message set"});
+    }
 }

--- a/Cpp/fost-urlhandler/test.throw.tests.cpp
+++ b/Cpp/fost-urlhandler/test.throw.tests.cpp
@@ -9,6 +9,8 @@
 #include <fost/urlhandler>
 #include <fost/test>
 
+#include <stdexcept>
+
 
 FSL_TEST_SUITE(throw_exception);
 
@@ -20,7 +22,7 @@ FSL_TEST_FUNCTION(empty_config) {
         auto const response{fostlib::urlhandler::test_throw(
                 config, "", req, fostlib::host{})};
         FSL_CHECK(false);
-    } catch (std::invalid_argument &) {}
+    } catch (const std::invalid_argument &) {}
 }
 
 
@@ -32,7 +34,7 @@ FSL_TEST_FUNCTION(logic_error) {
         auto const response{fostlib::urlhandler::test_throw(
                 config, "", req, fostlib::host{})};
         FSL_CHECK(false);
-    } catch (std::logic_error &e) {
+    } catch (const std::logic_error &e) {
         FSL_CHECK_EQ(
                 e.what(),
                 std::string{"Test exception message from test.throw"});
@@ -42,7 +44,7 @@ FSL_TEST_FUNCTION(logic_error) {
         auto const response{fostlib::urlhandler::test_throw(
                 config, "", req, fostlib::host{})};
         FSL_CHECK(false);
-    } catch (std::logic_error &e) {
+    } catch (const std::logic_error &e) {
         FSL_CHECK_EQ(e.what(), std::string{"Message set"});
     }
 }

--- a/Cpp/include/fost/urlhandler.hpp
+++ b/Cpp/include/fost/urlhandler.hpp
@@ -1,8 +1,8 @@
-/*
-    Copyright 2011-2018, Felspar Co Ltd. http://support.felspar.com/
+/**
+    Copyright 2011-2019, Felspar Co Ltd. <http://support.felspar.com/>
+
     Distributed under the Boost Software License, Version 1.0.
-    See accompanying file LICENSE_1_0.txt or copy at
-        http://www.boost.org/LICENSE_1_0.txt
+    See <http://www.boost.org/LICENSE_1_0.txt>
 */
 
 
@@ -84,9 +84,28 @@ namespace fostlib {
                 fostlib::http::server::request &req,
                 const boost::filesystem::path &filename);
 
+
+        /// ## Test views
+
+        /// Throw an exception
+        FOST_URLHANDLER_DECLSPEC
+        extern const view &test_throw;
+
+        /// ## Control flow views
+
         /// status condition view
         FOST_URLHANDLER_DECLSPEC
         extern const view &control_status_condition;
+
+        /// Runs the view found at the location with the longest prefix
+        FOST_URLHANDLER_DECLSPEC
+        extern const view &view_pathprefix;
+        /// Serves the view found based on an exact match of the URL
+        FOST_URLHANDLER_DECLSPEC
+        extern const view &view_pathname;
+
+
+        /// ## Middleware
 
         /// Log the request and results
         FOST_URLHANDLER_DECLSPEC
@@ -97,6 +116,13 @@ namespace fostlib {
         /// Wrap a template around a response
         FOST_URLHANDLER_DECLSPEC
         extern const view &middleware_template;
+
+        /// request body JSON Schema validation
+        FOST_URLHANDLER_DECLSPEC
+        extern const view &schema_validation;
+
+
+        /// ## Standard responses
 
         /// Return a 200 response to the user
         FOST_URLHANDLER_DECLSPEC
@@ -137,20 +163,12 @@ namespace fostlib {
         FOST_URLHANDLER_DECLSPEC
         extern const view &response_503;
 
+
+        /// ## Serving files
+
         /// Returns static files
         FOST_URLHANDLER_DECLSPEC
         extern const view &static_server;
-
-        /// request body JSON Schema validation
-        FOST_URLHANDLER_DECLSPEC
-        extern const view &schema_validation;
-
-        /// Runs the view found at the location with the longest prefix
-        FOST_URLHANDLER_DECLSPEC
-        extern const view &view_pathprefix;
-        /// Serves the view found based on an exact match of the URL
-        FOST_URLHANDLER_DECLSPEC
-        extern const view &view_pathname;
 
 
     }

--- a/Cpp/include/fost/urlhandler.hpp
+++ b/Cpp/include/fost/urlhandler.hpp
@@ -93,9 +93,13 @@ namespace fostlib {
 
         /// ## Control flow views
 
-        /// status condition view
+        /// Routing to new views based on status condition
         FOST_URLHANDLER_DECLSPEC
         extern const view &control_status_condition;
+        /// Catching exceptions and routing to different views
+        FOST_URLHANDLER_DECLSPEC
+        extern const view &control_exception_catch;
+
 
         /// Runs the view found at the location with the longest prefix
         FOST_URLHANDLER_DECLSPEC


### PR DESCRIPTION
This allows us to configure something for `std::exception`, which should be just enough for handling upstream TCP errors for the proxy view