### PR TITLE
The `test.throw` view now allows new exception throwers to be added

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,6 @@
+2019-03-05  Kirit Saelensminde  <kirit@felspar.com>
+ The `test.throw` view now allows new exception throwers to be added.
+
 2019-01-23  Kirit Saelensminde  <kirit@felspar.com>
  Add `test.throw` view to help with testing and `control.exception.catch` for running alternative views when exceptions are thrown.
 

--- a/Cpp/fost-urlhandler/test.throw.cpp
+++ b/Cpp/fost-urlhandler/test.throw.cpp
@@ -7,6 +7,7 @@
 
 
 #include "fost-urlhandler.hpp"
+#include <fost/test-throw-view.hpp>
 #include <fost/urlhandler.hpp>
 #include <f5/threading/map.hpp>
 
@@ -69,3 +70,9 @@ namespace {
 
 const fostlib::urlhandler::view &fostlib::urlhandler::test_throw =
         c_throw_exception;
+
+
+fostlib::urlhandler::test_throw_plugin::test_throw_plugin(fostlib::string n, test_throw_plugin_fn f) {
+    g_pthrowers->emplace_if_not_found(std::move(n), std::move(f));
+}
+

--- a/Cpp/include/fost/test-throw-view.hpp
+++ b/Cpp/include/fost/test-throw-view.hpp
@@ -1,0 +1,28 @@
+/**
+    Copyright 2019, Felspar Co Ltd. <http://support.felspar.com/>
+
+    Distributed under the Boost Software License, Version 1.0.
+    See <http://www.boost.org/LICENSE_1_0.txt>
+*/
+
+
+#pragma once
+
+
+#include <fost/core>
+#include <functional>
+
+
+namespace fostlib::urlhandler {
+
+
+    using test_throw_plugin_fn = std::function<void(fostlib::string)>;
+
+
+    struct test_throw_plugin {
+        test_throw_plugin(fostlib::string name, test_throw_plugin_fn);
+    };
+
+
+}
+


### PR DESCRIPTION
This is done through a plug-in mechanism. There's an example in the `Fostgres` code.