### PR TITLE
De-register throw plug ins if the code is unloaded

### DIFF
--- a/Cpp/fost-urlhandler/test.throw.cpp
+++ b/Cpp/fost-urlhandler/test.throw.cpp
@@ -17,9 +17,10 @@
 namespace {
 
 
-    auto const g_pthrowers = [](){
-        auto map = std::make_unique<f5::tsmap<fostlib::string, std::function<void(fostlib::string)>>>();
-        map->emplace_if_not_found("std::logic_error", [](fostlib::string msg){
+    auto const g_pthrowers = []() {
+        auto map = std::make_unique<f5::tsmap<
+                fostlib::string, std::function<void(fostlib::string)>>>();
+        map->emplace_if_not_found("std::logic_error", [](fostlib::string msg) {
             throw std::logic_error{static_cast<std::string>(msg)};
         });
         return map;
@@ -46,19 +47,25 @@ namespace {
                                         "Test exception message from "
                                         "test.throw");
                 if (config.has_key("exception")) {
-                    auto const exception_name = fostlib::coerce<fostlib::string>(config["exception"]);
+                    auto const exception_name =
+                            fostlib::coerce<fostlib::string>(
+                                    config["exception"]);
                     auto const pthrower = g_pthrowers->find(exception_name);
-                    if(pthrower) {
+                    if (pthrower) {
                         pthrower(message);
                         throw fostlib::exceptions::not_implemented(
-                            __PRETTY_FUNCTION__, "Exception thrower didn't throw", exception_name);
+                                __PRETTY_FUNCTION__,
+                                "Exception thrower didn't throw",
+                                exception_name);
                     } else {
                         throw fostlib::exceptions::not_implemented(
-                            __PRETTY_FUNCTION__, "Exception name not found", exception_name);
+                                __PRETTY_FUNCTION__, "Exception name not found",
+                                exception_name);
                     }
                 } else {
                     throw fostlib::exceptions::not_implemented(
-                            __PRETTY_FUNCTION__, "No exception name given to be thrown");
+                            __PRETTY_FUNCTION__,
+                            "No exception name given to be thrown");
                 }
             }
         }

--- a/Cpp/fost-urlhandler/test.throw.cpp
+++ b/Cpp/fost-urlhandler/test.throw.cpp
@@ -79,7 +79,13 @@ const fostlib::urlhandler::view &fostlib::urlhandler::test_throw =
         c_throw_exception;
 
 
-fostlib::urlhandler::test_throw_plugin::test_throw_plugin(fostlib::string n, test_throw_plugin_fn f) {
+fostlib::urlhandler::test_throw_plugin::test_throw_plugin(
+        fostlib::string n, test_throw_plugin_fn f)
+: name{n} {
     g_pthrowers->emplace_if_not_found(std::move(n), std::move(f));
 }
 
+
+fostlib::urlhandler::test_throw_plugin::~test_throw_plugin() {
+    g_pthrowers->remove(name);
+}

--- a/Cpp/include/fost/test-throw-view.hpp
+++ b/Cpp/include/fost/test-throw-view.hpp
@@ -21,8 +21,11 @@ namespace fostlib::urlhandler {
 
     struct test_throw_plugin {
         test_throw_plugin(fostlib::string name, test_throw_plugin_fn);
+        ~test_throw_plugin();
+
+      private:
+        string name;
     };
 
 
 }
-


### PR DESCRIPTION
This isn't strictly necessary because shared code won't be unloaded until the process dies, but it is better with it than without it. It allows plugins to be shorter lived than the process itself.